### PR TITLE
use swiv-plywood

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -745,11 +745,6 @@
       "from": "pinkie-promise@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
-    "plywood": {
-      "version": "0.12.3",
-      "from": "plywood@0.12.3",
-      "resolved": "https://registry.npmjs.org/plywood/-/plywood-0.12.3.tgz"
-    },
     "plywood-druid-requester": {
       "version": "1.5.4",
       "from": "plywood-druid-requester@1.5.4",
@@ -941,6 +936,11 @@
       "version": "2.0.0",
       "from": "supports-color@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+    },
+    "swiv-plywood": {
+      "version": "0.12.17",
+      "from": "swiv-plywood@0.12.17",
+      "resolved": "https://registry.npmjs.org/swiv-plywood/-/swiv-plywood-0.12.17.tgz"
     },
     "thenify": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "node-spawn-server": "1.0.1",
     "nopt": "3.0.6",
     "numeral": "1.5.3",
-    "plywood": "0.12.3",
     "plywood-druid-requester": "1.5.4",
     "plywood-mysql-requester": "1.3.1",
     "plywood-postgres-requester": "0.9.1",
@@ -50,7 +49,8 @@
     "react": "15.3.0",
     "react-addons-css-transition-group": "15.3.0",
     "react-dom": "15.3.0",
-    "request": "2.74.0"
+    "request": "2.74.0",
+    "swiv-plywood": "0.12.17"
   },
   "devDependencies": {
     "@types/body-parser": "0.0.30",

--- a/script/mkcomp
+++ b/script/mkcomp
@@ -80,7 +80,7 @@ require('./${name}.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Stage, Clicker, Essence, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';
 // import { ... } from '../../config/constants';
 // import { Fn } from '../../../common/utils/general/general';
@@ -144,7 +144,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock, EssenceMock } from '../../../common/models/mocks';
 

--- a/script/mkmodel
+++ b/script/mkmodel
@@ -72,7 +72,7 @@ writeFile(path + name + '.ts',
  */
 
 import { BaseImmutable, Property, isInstanceOf } from 'immutable-class';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 // I am: export * from './${name}/${name}';
 
@@ -130,7 +130,7 @@ writeFile(path + name + '.mocha.ts',
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { ${camelName} } from './${name}';
 
 describe('${camelName}', () => {

--- a/src/client/applications/swiv-application/swiv-application.mocha.tsx
+++ b/src/client/applications/swiv-application/swiv-application.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { SwivApplication } from './swiv-application';
 
 describe.skip('SwivApplication', () => {

--- a/src/client/applications/swiv-application/swiv-application.tsx
+++ b/src/client/applications/swiv-application/swiv-application.tsx
@@ -19,7 +19,7 @@ require('./swiv-application.css');
 import * as React from 'react';
 import * as Q from 'q';
 import * as ReactCSSTransitionGroup from 'react-addons-css-transition-group';
-import { findByName } from 'plywood';
+import { findByName } from 'swiv-plywood';
 
 import { replaceHash } from '../../utils/url/url';
 import { DataCube, AppSettings, User, Collection, CollectionTile, Essence, Timekeeper, ViewSupervisor } from '../../../common/models/index';

--- a/src/client/components/body-portal/body-portal.mocha.tsx
+++ b/src/client/components/body-portal/body-portal.mocha.tsx
@@ -23,7 +23,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { BodyPortal } from './body-portal';
 
 describe('BodyPortal', () => {

--- a/src/client/components/bubble-menu/bubble-menu.mocha.tsx
+++ b/src/client/components/bubble-menu/bubble-menu.mocha.tsx
@@ -22,7 +22,7 @@ import * as ReactDOM from 'react-dom';
 import * as TestUtils from 'react-addons-test-utils';
 import { findDOMNode } from '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { BubbleMenu } from './bubble-menu';
 
 import { StageMock } from '../../../common/models/mocks';

--- a/src/client/components/bucket-marks/bucket-marks.mocha.tsx
+++ b/src/client/components/bucket-marks/bucket-marks.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression, PlywoodValue } from 'plywood';
+import { $, Expression, PlywoodValue } from 'swiv-plywood';
 import { BucketMarks } from './bucket-marks';
 
 import { StageMock } from '../../../common/models/mocks';

--- a/src/client/components/bucket-marks/bucket-marks.tsx
+++ b/src/client/components/bucket-marks/bucket-marks.tsx
@@ -17,7 +17,7 @@
 require('./bucket-marks.css');
 
 import * as React from 'react';
-import { PlywoodValue } from 'plywood';
+import { PlywoodValue } from 'swiv-plywood';
 import { Stage } from '../../../common/models/index';
 import { roundToHalfPx } from '../../utils/dom/dom';
 

--- a/src/client/components/button-group/button-group.mocha.tsx
+++ b/src/client/components/button-group/button-group.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { ButtonGroup } from './button-group';
 
 describe('ButtonGroup', () => {

--- a/src/client/components/button/button.mocha.tsx
+++ b/src/client/components/button/button.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Button } from './button';
 
 describe('Button', () => {

--- a/src/client/components/chart-line/chart-line.mocha.tsx
+++ b/src/client/components/chart-line/chart-line.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { Dataset, TimeRange } from 'plywood';
+import { Dataset, TimeRange } from 'swiv-plywood';
 import { ChartLine } from './chart-line';
 
 import { StageMock } from '../../../common/models/mocks';

--- a/src/client/components/chart-line/chart-line.tsx
+++ b/src/client/components/chart-line/chart-line.tsx
@@ -20,7 +20,7 @@ import { immutableEqual } from 'immutable-class';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as d3 from 'd3';
-import { $, Expression, Executor, Dataset, Datum, TimeRange, PlywoodRange, NumberRange, Range } from 'plywood';
+import { $, Expression, Executor, Dataset, Datum, TimeRange, PlywoodRange, NumberRange, Range } from 'swiv-plywood';
 import { Stage, Filter, Dimension, Measure } from '../../../common/models/index';
 
 const lineFn = d3.svg.line();

--- a/src/client/components/checkbox/checkbox.mocha.tsx
+++ b/src/client/components/checkbox/checkbox.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Checkbox } from './checkbox';
 
 describe('Checkbox', () => {

--- a/src/client/components/clearable-input/clearable-input.mocha.tsx
+++ b/src/client/components/clearable-input/clearable-input.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { ClearableInput } from './clearable-input';
 
 describe('ClearableInput', () => {

--- a/src/client/components/clearable-input/clearable-input.tsx
+++ b/src/client/components/clearable-input/clearable-input.tsx
@@ -18,7 +18,7 @@ require('./clearable-input.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Stage, Essence, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';
 import { SvgIcon } from '../svg-icon/svg-icon';
 

--- a/src/client/components/date-range-input/date-range-input.mocha.tsx
+++ b/src/client/components/date-range-input/date-range-input.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { DateRangeInput } from './date-range-input';
 
 describe('DateRangeInput', () => {

--- a/src/client/components/date-range-picker/date-range-picker.tsx
+++ b/src/client/components/date-range-picker/date-range-picker.tsx
@@ -18,7 +18,7 @@ require('./date-range-picker.css');
 
 import * as React from 'react';
 import { Timezone, Duration, second, minute, hour, day, week, month, year } from 'chronoshift';
-import { TimeRange } from 'plywood';
+import { TimeRange } from 'swiv-plywood';
 import {
   prependDays, appendDays, datesEqual, monthToWeeks, shiftOneDay, getWallTimeMonthWithYear,
   getWallTimeDay, wallTimeInclusiveEndEqual, getEndWallTimeInclusive

--- a/src/client/components/dimension-actions-menu/dimension-actions-menu.mocha.tsx
+++ b/src/client/components/dimension-actions-menu/dimension-actions-menu.mocha.tsx
@@ -24,7 +24,7 @@ import '../../utils/test-utils/index';
 import * as TestUtils from 'react-addons-test-utils';
 import { findDOMNode } from '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { DimensionActionsMenu } from './dimension-actions-menu';
 
 import { EssenceMock, StageMock, DimensionMock } from '../../../common/models/mocks';

--- a/src/client/components/dimension-list-tile/dimension-list-tile.mocha.tsx
+++ b/src/client/components/dimension-list-tile/dimension-list-tile.mocha.tsx
@@ -24,7 +24,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import { EssenceMock } from '../../../common/models/mocks';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 describe('DimensionListTile', () => {
   var { DimensionListTile } = mockRequireEnsure('./dimension-list-tile');

--- a/src/client/components/dimension-measure-panel/dimension-measure-panel.mocha.tsx
+++ b/src/client/components/dimension-measure-panel/dimension-measure-panel.mocha.tsx
@@ -19,7 +19,7 @@ import * as sinon from 'sinon';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { mockRequireEnsure, mockReactComponent } from '../../utils/test-utils/index';
 import { EssenceMock } from '../../../common/models/mocks';

--- a/src/client/components/dimension-tile/dimension-tile.tsx
+++ b/src/client/components/dimension-tile/dimension-tile.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 
 import { Duration } from 'chronoshift';
 import { List } from 'immutable';
-import { $, r, Dataset, SortAction, TimeRange, RefExpression, Expression, TimeBucketAction, NumberRange } from 'plywood';
+import { $, r, Dataset, SortAction, TimeRange, RefExpression, Expression, TimeBucketAction, NumberRange } from 'swiv-plywood';
 
 import { formatterFromData, collect, formatGranularity, formatTimeBasedOnGranularity, formatNumberRange } from '../../../common/utils/index';
 import { Fn } from '../../../common/utils/general/general';

--- a/src/client/components/drop-indicator/drop-indicator.mocha.tsx
+++ b/src/client/components/drop-indicator/drop-indicator.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { DropIndicator } from './drop-indicator';
 
 describe('DropIndicator', () => {

--- a/src/client/components/dropdown/dropdown.tsx
+++ b/src/client/components/dropdown/dropdown.tsx
@@ -19,7 +19,7 @@ require('./dropdown.css');
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { SvgIcon } from '../svg-icon/svg-icon';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Stage, Essence, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';
 import { isInside, escapeKey, classNames } from '../../utils/dom/dom';
 

--- a/src/client/components/filter-options-dropdown/filter-options-dropdown.mocha.tsx
+++ b/src/client/components/filter-options-dropdown/filter-options-dropdown.mocha.tsx
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock, EssenceMock } from '../../../common/models/mocks';
 

--- a/src/client/components/form-label/form-label.mocha.tsx
+++ b/src/client/components/form-label/form-label.mocha.tsx
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock, EssenceMock } from '../../../common/models/mocks';
 

--- a/src/client/components/form-label/form-label.tsx
+++ b/src/client/components/form-label/form-label.tsx
@@ -18,7 +18,7 @@ require('./form-label.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Stage, Clicker, Essence, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';
 import { SvgIcon } from '../svg-icon/svg-icon';
 import { classNames } from '../../utils/dom/dom';

--- a/src/client/components/global-event-listener/global-event-listener.mocha.tsx
+++ b/src/client/components/global-event-listener/global-event-listener.mocha.tsx
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { findDOMNode } from '../../utils/test-utils/index';
 

--- a/src/client/components/golden-center/golden-center.mocha.tsx
+++ b/src/client/components/golden-center/golden-center.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { GoldenCenter } from './golden-center';
 
 describe('GoldenCenter', () => {

--- a/src/client/components/grid-lines/grid-lines.mocha.tsx
+++ b/src/client/components/grid-lines/grid-lines.mocha.tsx
@@ -25,7 +25,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import { StageMock } from '../../../common/models/mocks';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { GridLines } from './grid-lines';
 
 describe('GridLines', () => {

--- a/src/client/components/highlight-string/highlight-string.mocha.tsx
+++ b/src/client/components/highlight-string/highlight-string.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { HighlightString } from './highlight-string';
 
 describe('HighlightString', () => {

--- a/src/client/components/highlighter/highlighter.mocha.tsx
+++ b/src/client/components/highlighter/highlighter.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { TimeRange } from 'plywood';
+import { TimeRange } from 'swiv-plywood';
 import { Highlighter } from './highlighter';
 
 describe('Highlighter', () => {

--- a/src/client/components/highlighter/highlighter.tsx
+++ b/src/client/components/highlighter/highlighter.tsx
@@ -18,7 +18,7 @@ require('./highlighter.css');
 
 import * as React from 'react';
 import { Timezone, Duration } from 'chronoshift';
-import { PlywoodRange } from 'plywood';
+import { PlywoodRange } from 'swiv-plywood';
 
 export interface HighlighterProps extends React.Props<any> {
   highlightRange: PlywoodRange;

--- a/src/client/components/hiluk-menu/hiluk-menu.mocha.tsx
+++ b/src/client/components/hiluk-menu/hiluk-menu.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 import { findDOMNode } from '../../utils/test-utils/index';
 import { EssenceMock, TimekeeperMock } from '../../../common/models/mocks';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { HilukMenu } from './hiluk-menu';
 
 describe.skip('HilukMenu', () => {

--- a/src/client/components/hiluk-menu/hiluk-menu.tsx
+++ b/src/client/components/hiluk-menu/hiluk-menu.tsx
@@ -17,7 +17,7 @@
 require('./hiluk-menu.css');
 
 import * as React from 'react';
-import { Dataset } from 'plywood';
+import { Dataset } from 'swiv-plywood';
 import { Fn } from '../../../common/utils/general/general';
 import { Stage, Essence, Timekeeper, ExternalView } from '../../../common/models/index';
 import { STRINGS } from '../../config/constants';

--- a/src/client/components/hover-multi-bubble/hover-multi-bubble.mocha.tsx
+++ b/src/client/components/hover-multi-bubble/hover-multi-bubble.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { HoverMultiBubble } from './hover-multi-bubble';
 
 describe.skip('HoverMultiBubble', () => {

--- a/src/client/components/immutable-dropdown/immutable-dropdown.mocha.tsx
+++ b/src/client/components/immutable-dropdown/immutable-dropdown.mocha.tsx
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock } from '../../../common/models/mocks';
 import { DataCube, ListItem, Cluster } from '../../../common/models/index';

--- a/src/client/components/immutable-dropdown/immutable-dropdown.tsx
+++ b/src/client/components/immutable-dropdown/immutable-dropdown.tsx
@@ -20,7 +20,7 @@ import { ImmutableUtils } from '../../../common/utils/index';
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Stage, Clicker, Essence, DataCube, Filter, Dimension, Measure, ListItem } from '../../../common/models/index';
 import { ChangeFn } from '../../utils/immutable-form-delegate/immutable-form-delegate';
 import { SvgIcon } from '../svg-icon/svg-icon';

--- a/src/client/components/immutable-input/immutable-input.mocha.tsx
+++ b/src/client/components/immutable-input/immutable-input.mocha.tsx
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCube } from '../../../common/models/index';
 import { DataCubeMock } from '../../../common/models/mocks';

--- a/src/client/components/loader/loader.mocha.tsx
+++ b/src/client/components/loader/loader.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Loader } from './loader';
 
 describe('Loader', () => {

--- a/src/client/components/manual-fallback/manual-fallback.mocha.tsx
+++ b/src/client/components/manual-fallback/manual-fallback.mocha.tsx
@@ -25,7 +25,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import { EssenceMock } from '../../../common/models/mocks';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { ManualFallback } from './manual-fallback';
 
 describe('ManualFallback', () => {

--- a/src/client/components/measures-tile/measures-tile.mocha.tsx
+++ b/src/client/components/measures-tile/measures-tile.mocha.tsx
@@ -25,7 +25,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import { EssenceMock } from '../../../common/models/mocks';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { MeasuresTile } from './measures-tile';
 
 describe('MeasuresTile', () => {

--- a/src/client/components/modal/modal.mocha.tsx
+++ b/src/client/components/modal/modal.mocha.tsx
@@ -24,7 +24,7 @@ import { findDOMNode } from '../../utils/test-utils/index';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Modal } from './modal';
 
 describe('Modal', () => {

--- a/src/client/components/nav-list/nav-list.mocha.tsx
+++ b/src/client/components/nav-list/nav-list.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { NavList } from './nav-list';
 
 describe('NavList', () => {

--- a/src/client/components/nav-logo/nav-logo.mocha.tsx
+++ b/src/client/components/nav-logo/nav-logo.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { NavLogo } from './nav-logo';
 
 describe('NavLogo', () => {

--- a/src/client/components/nav-logo/nav-logo.tsx
+++ b/src/client/components/nav-logo/nav-logo.tsx
@@ -18,7 +18,7 @@ require('./nav-logo.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Stage, Clicker, Essence, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';
 import { SvgIcon } from '../svg-icon/svg-icon';
 

--- a/src/client/components/notifications/notifications.mocha.tsx
+++ b/src/client/components/notifications/notifications.mocha.tsx
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock, EssenceMock } from '../../../common/models/mocks';
 

--- a/src/client/components/number-filter-menu/number-filter-menu.tsx
+++ b/src/client/components/number-filter-menu/number-filter-menu.tsx
@@ -17,7 +17,7 @@
 require('./number-filter-menu.css');
 
 import * as React from 'react';
-import { Set, NumberRange, LiteralExpression } from 'plywood';
+import { Set, NumberRange, LiteralExpression } from 'swiv-plywood';
 
 import { FilterClause, Clicker, Essence, Timekeeper, Filter, Dimension, FilterMode, Stage } from '../../../common/models/index';
 import { Fn } from '../../../common/utils/general/general';

--- a/src/client/components/number-range-picker/number-range-picker.tsx
+++ b/src/client/components/number-range-picker/number-range-picker.tsx
@@ -19,7 +19,7 @@ require('./number-range-picker.css');
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import { $, Dataset, ply } from 'plywood';
+import { $, Dataset, ply } from 'swiv-plywood';
 
 import { Essence, Timekeeper, Dimension } from '../../../common/models/index';
 import { toSignificantDigits, getNumberOfWholeDigits } from '../../../common/utils/general/general';

--- a/src/client/components/pinboard-measure-tile/pinboard-measure-tile.mocha.tsx
+++ b/src/client/components/pinboard-measure-tile/pinboard-measure-tile.mocha.tsx
@@ -26,7 +26,7 @@ import * as TestUtils from 'react-addons-test-utils';
 import { SortOn } from '../../../common/models/index';
 import { EssenceMock } from '../../../common/models/mocks';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { PinboardMeasureTile } from './pinboard-measure-tile';
 
 describe('PinboardMeasureTile', () => {

--- a/src/client/components/pinboard-panel/pinboard-panel.tsx
+++ b/src/client/components/pinboard-panel/pinboard-panel.tsx
@@ -17,7 +17,7 @@
 require('./pinboard-panel.css');
 
 import * as React from 'react';
-import { $, Expression, SortAction } from 'plywood';
+import { $, Expression, SortAction } from 'swiv-plywood';
 import { STRINGS } from '../../config/constants';
 import { SvgIcon } from '../svg-icon/svg-icon';
 import { Clicker, Essence, Timekeeper, SortOn, VisStrategy, Colors } from '../../../common/models/index';

--- a/src/client/components/preview-string-filter-menu/preview-string-filter-menu.tsx
+++ b/src/client/components/preview-string-filter-menu/preview-string-filter-menu.tsx
@@ -17,7 +17,7 @@
 require('./preview-string-filter-menu.css');
 
 import * as React from "react";
-import { $, Dataset, SortAction, r } from "plywood";
+import { $, Dataset, SortAction, r } from "swiv-plywood";
 import { Fn, collect } from "../../../common/utils/general/general";
 import { STRINGS, SEARCH_WAIT } from "../../config/constants";
 import { Clicker, Essence, Timekeeper, Filter, FilterClause, FilterMode, Dimension } from "../../../common/models/index";

--- a/src/client/components/query-error/query-error.mocha.tsx
+++ b/src/client/components/query-error/query-error.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { QueryError } from './query-error';
 
 describe('QueryError', () => {

--- a/src/client/components/resize-handle/resize-handle.mocha.tsx
+++ b/src/client/components/resize-handle/resize-handle.mocha.tsx
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock, EssenceMock } from '../../../common/models/mocks';
 

--- a/src/client/components/router/router.mocha.tsx
+++ b/src/client/components/router/router.mocha.tsx
@@ -21,7 +21,7 @@ import * as sinon from 'sinon';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock, EssenceMock } from '../../../common/models/mocks';
 

--- a/src/client/components/router/router.tsx
+++ b/src/client/components/router/router.tsx
@@ -18,7 +18,7 @@ require('./router.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Stage, Clicker, Essence, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';
 import { replaceHash } from '../../utils/url/url';
 import { extend } from '../../../common/utils/object/object';

--- a/src/client/components/searchable-tile/searchable-tile.mocha.tsx
+++ b/src/client/components/searchable-tile/searchable-tile.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { SearchableTile } from './searchable-tile';
 
 describe('SearchableTile', () => {

--- a/src/client/components/segment-action-buttons/segment-action-buttons.mocha.tsx
+++ b/src/client/components/segment-action-buttons/segment-action-buttons.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { SegmentActionButtons } from './segment-action-buttons';
 
 describe('SegmentActionButtons', () => {

--- a/src/client/components/segment-action-buttons/segment-action-buttons.tsx
+++ b/src/client/components/segment-action-buttons/segment-action-buttons.tsx
@@ -18,7 +18,7 @@ require('./segment-action-buttons.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Fn } from '../../../common/utils/general/general';
 import { Stage, Clicker, Essence, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';
 import { STRINGS } from '../../config/constants';

--- a/src/client/components/segment-bubble/segment-bubble.mocha.tsx
+++ b/src/client/components/segment-bubble/segment-bubble.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { SegmentBubble } from './segment-bubble';
 
 describe.skip('SegmentBubble', () => {

--- a/src/client/components/selectable-string-filter-menu/selectable-string-filter-menu.tsx
+++ b/src/client/components/selectable-string-filter-menu/selectable-string-filter-menu.tsx
@@ -17,7 +17,7 @@
 require('./selectable-string-filter-menu.css');
 
 import * as React from "react";
-import { $, r, Dataset, SortAction, Set } from "plywood";
+import { $, r, Dataset, SortAction, Set } from "swiv-plywood";
 import { Fn, collect } from "../../../common/utils/general/general";
 import { STRINGS, SEARCH_WAIT } from "../../config/constants";
 import { Clicker, Essence, Timekeeper, Filter, FilterClause, FilterMode, Dimension, Colors } from "../../../common/models/index";

--- a/src/client/components/shpitz/shpitz.mocha.tsx
+++ b/src/client/components/shpitz/shpitz.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Shpitz } from './shpitz';
 
 describe('Shpitz', () => {

--- a/src/client/components/side-drawer/side-drawer.mocha.tsx
+++ b/src/client/components/side-drawer/side-drawer.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { SideDrawer } from './side-drawer';
 
 describe.skip('SideDrawer', () => {

--- a/src/client/components/simple-list/simple-list.mocha.tsx
+++ b/src/client/components/simple-list/simple-list.mocha.tsx
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock, EssenceMock } from '../../../common/models/mocks';
 

--- a/src/client/components/simple-list/simple-list.tsx
+++ b/src/client/components/simple-list/simple-list.tsx
@@ -18,7 +18,7 @@ require('./simple-list.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 
 import { setDragGhost, classNames, getYFromEvent } from '../../utils/dom/dom';
 import { Stage, Clicker, Essence, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';

--- a/src/client/components/simple-table/simple-table.mocha.tsx
+++ b/src/client/components/simple-table/simple-table.mocha.tsx
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock, EssenceMock } from '../../../common/models/mocks';
 

--- a/src/client/components/simple-table/simple-table.tsx
+++ b/src/client/components/simple-table/simple-table.tsx
@@ -18,7 +18,7 @@ require('./simple-table.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Stage, Clicker, Essence, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';
 
 import { classNames } from '../../utils/dom/dom';

--- a/src/client/components/split-menu/split-menu.mocha.tsx
+++ b/src/client/components/split-menu/split-menu.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { SplitMenu } from './split-menu';
 
 describe.skip('SplitMenu', () => {

--- a/src/client/components/split-menu/split-menu.tsx
+++ b/src/client/components/split-menu/split-menu.tsx
@@ -18,7 +18,7 @@ require('./split-menu.css');
 
 import * as React from "react";
 import { Timezone, Duration } from "chronoshift";
-import { TimeBucketAction, NumberBucketAction, SortAction } from "plywood";
+import { TimeBucketAction, NumberBucketAction, SortAction } from "swiv-plywood";
 import { Fn, formatGranularity } from "../../../common/utils/index";
 import {
   Stage,

--- a/src/client/components/svg-icon/svg-icon.mocha.tsx
+++ b/src/client/components/svg-icon/svg-icon.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { SvgIcon } from './svg-icon';
 
 describe('SvgIcon', () => {

--- a/src/client/components/svg-icon/svg-icon.tsx
+++ b/src/client/components/svg-icon/svg-icon.tsx
@@ -19,7 +19,7 @@ require('./svg-icon.css');
 import { List } from 'immutable';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Stage, DataCube, Filter, Dimension, Measure } from '../../../common/models/index';
 
 // Inspired by: https://gist.github.com/MoOx/1eb30eac43b2114de73a

--- a/src/client/components/tile-header/tile-header.mocha.tsx
+++ b/src/client/components/tile-header/tile-header.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { TileHeader } from './tile-header';
 
 describe('TileHeader', () => {

--- a/src/client/components/time-filter-menu/time-filter-menu.tsx
+++ b/src/client/components/time-filter-menu/time-filter-menu.tsx
@@ -18,7 +18,7 @@ require('./time-filter-menu.css');
 
 import * as React from "react";
 import { Timezone, second, day } from "chronoshift";
-import { $, r, Expression, LiteralExpression, TimeRange, Range, Set } from "plywood";
+import { $, r, Expression, LiteralExpression, TimeRange, Range, Set } from "swiv-plywood";
 import { Fn } from "../../../common/utils/general/general";
 import { STRINGS } from "../../config/constants";
 import { Clicker, Essence, Timekeeper, Filter, FilterClause, Dimension } from "../../../common/models/index";

--- a/src/client/components/user-menu/user-menu.mocha.tsx
+++ b/src/client/components/user-menu/user-menu.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { UserMenu } from './user-menu';
 
 describe.skip('UserMenu', () => {

--- a/src/client/components/vertical-axis/vertical-axis.mocha.tsx
+++ b/src/client/components/vertical-axis/vertical-axis.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { VerticalAxis } from './vertical-axis';
 
 describe.skip('VerticalAxis', () => {

--- a/src/client/components/vis-measure-label/vis-measure-label.mocha.tsx
+++ b/src/client/components/vis-measure-label/vis-measure-label.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { VisMeasureLabel } from './vis-measure-label';
 
 describe.skip('VisMeasureLabel', () => {

--- a/src/client/components/vis-measure-label/vis-measure-label.tsx
+++ b/src/client/components/vis-measure-label/vis-measure-label.tsx
@@ -17,7 +17,7 @@
 require('./vis-measure-label.css');
 
 import * as React from 'react';
-import { Datum } from 'plywood';
+import { Datum } from 'swiv-plywood';
 import { Measure } from '../../../common/models/index';
 
 export interface VisMeasureLabelProps extends React.Props<any> {

--- a/src/client/components/vis-selector-menu/vis-selector-menu.mocha.tsx
+++ b/src/client/components/vis-selector-menu/vis-selector-menu.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { VisSelectorMenu } from './vis-selector-menu';
 
 describe.skip('VisSelectorMenu', () => {

--- a/src/client/components/vis-selector/vis-selector.mocha.tsx
+++ b/src/client/components/vis-selector/vis-selector.mocha.tsx
@@ -23,7 +23,7 @@ import '../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { VisSelector } from './vis-selector';
 
 describe.skip('VisSelector', () => {

--- a/src/client/config/constants.ts
+++ b/src/client/config/constants.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { $, SortAction } from 'plywood';
+import { $, SortAction } from 'swiv-plywood';
 import { Locale } from '../../common/utils/time/time';
 
 export const TITLE_HEIGHT = 36;

--- a/src/client/modals/add-collection-tile-modal/add-collection-tile-modal.mocha.tsx
+++ b/src/client/modals/add-collection-tile-modal/add-collection-tile-modal.mocha.tsx
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { findDOMNode } from '../../utils/test-utils/index';
 import { TimekeeperMock } from '../../../common/models/mocks';

--- a/src/client/modals/add-collection-tile-modal/add-collection-tile-modal.tsx
+++ b/src/client/modals/add-collection-tile-modal/add-collection-tile-modal.tsx
@@ -2,7 +2,7 @@ require('./add-collection-tile-modal.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Collection, Essence, Timekeeper, CollectionTile, DataCube, SortOn } from '../../../common/models/index';
 import { classNames } from '../../utils/dom/dom';
 import { generateUniqueName } from '../../../common/utils/string/string';

--- a/src/client/modals/name-description-modal/name-description-modal.tsx
+++ b/src/client/modals/name-description-modal/name-description-modal.tsx
@@ -2,7 +2,7 @@ require('./name-description-modal.css');
 
 import * as React from 'react';
 
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { Collection, Essence, CollectionTile, DataCube } from '../../../common/models/index';
 import { classNames } from '../../utils/dom/dom';
 import { ImmutableFormDelegate, ImmutableFormState } from '../../utils/immutable-form-delegate/immutable-form-delegate';

--- a/src/client/modals/raw-data-modal/raw-data-modal.tsx
+++ b/src/client/modals/raw-data-modal/raw-data-modal.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { List } from 'immutable';
 import { isDate } from 'chronoshift';
-import { $, Dataset, PlywoodValue, Datum, AttributeInfo } from 'plywood';
+import { $, Dataset, PlywoodValue, Datum, AttributeInfo } from 'swiv-plywood';
 import { Essence, Stage, DataCube, Timekeeper } from '../../../common/models/index';
 
 import { Fn, makeTitle, arraySum } from '../../../common/utils/general/general';

--- a/src/client/utils/ajax/ajax.ts
+++ b/src/client/utils/ajax/ajax.ts
@@ -16,7 +16,7 @@
 
 import * as Q from 'q';
 import * as Qajax from 'qajax';
-import { $, Expression, Executor, Dataset, ChainExpression, SplitAction, Environment } from 'plywood';
+import { $, Expression, Executor, Dataset, ChainExpression, SplitAction, Environment } from 'swiv-plywood';
 
 Qajax.defaults.timeout = 0; // We'll manage the timeout per request.
 

--- a/src/client/utils/download/download.mocha.ts
+++ b/src/client/utils/download/download.mocha.ts
@@ -16,7 +16,7 @@
 
 import { expect } from 'chai';
 import '../../utils/test-utils/index';
-import { Dataset } from 'plywood';
+import { Dataset } from 'swiv-plywood';
 import { datasetToFileString, getMIMEType } from './download';
 
 describe.skip('Download', () => {

--- a/src/client/utils/download/download.ts
+++ b/src/client/utils/download/download.ts
@@ -15,7 +15,7 @@
  */
 
 import * as filesaver from 'browser-filesaver';
-import { Dataset } from 'plywood';
+import { Dataset } from 'swiv-plywood';
 
 export type FileFormat = "csv" | "tsv" | "json" | "txt";
 

--- a/src/client/views/collection-view/collection-header-bar/collection-header-bar.mocha.tsx
+++ b/src/client/views/collection-view/collection-header-bar/collection-header-bar.mocha.tsx
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock, EssenceMock } from '../../../../common/models/mocks';
 

--- a/src/client/views/cube-view/cube-header-bar/cube-header-bar.tsx
+++ b/src/client/views/cube-view/cube-header-bar/cube-header-bar.tsx
@@ -19,7 +19,7 @@ require('./cube-header-bar.css');
 import * as React from 'react';
 import { immutableEqual } from "immutable-class";
 import { Duration, Timezone } from 'chronoshift';
-import { Dataset } from 'plywood';
+import { Dataset } from 'swiv-plywood';
 import { Fn } from '../../../../common/utils/general/general';
 import { classNames } from "../../../utils/dom/dom";
 

--- a/src/client/views/cube-view/cube-view.tsx
+++ b/src/client/views/cube-view/cube-view.tsx
@@ -18,7 +18,7 @@ require('./cube-view.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Expression, Dataset } from 'plywood';
+import { Expression, Dataset } from 'swiv-plywood';
 import { Timezone } from 'chronoshift';
 import { Fn } from '../../../common/utils/general/general';
 import { FunctionSlot } from '../../utils/function-slot/function-slot';

--- a/src/client/views/home-view/home-header-bar/home-header-bar.mocha.tsx
+++ b/src/client/views/home-view/home-header-bar/home-header-bar.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { HomeHeaderBar } from './home-header-bar';
 
 describe('HomeHeaderBar', () => {

--- a/src/client/views/home-view/home-view.mocha.tsx
+++ b/src/client/views/home-view/home-view.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { HomeView } from './home-view';
 
 describe.skip('HomeView', () => {

--- a/src/client/views/link-view/link-header-bar/link-header-bar.mocha.tsx
+++ b/src/client/views/link-view/link-header-bar/link-header-bar.mocha.tsx
@@ -23,7 +23,7 @@ import '../../../utils/test-utils/index';
 
 import * as TestUtils from 'react-addons-test-utils';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { LinkHeaderBar } from './link-header-bar';
 
 describe('LinkHeaderBar', () => {

--- a/src/client/views/link-view/link-view.tsx
+++ b/src/client/views/link-view/link-view.tsx
@@ -18,7 +18,7 @@ require('./link-view.css');
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Expression, $, find } from 'plywood';
+import { Expression, $, find } from 'swiv-plywood';
 import { Timezone } from 'chronoshift';
 import { classNames } from '../../utils/dom/dom';
 import { Fn } from '../../../common/utils/general/general';

--- a/src/client/views/no-data-view/no-data-header-bar/no-data-header-bar.mocha.tsx
+++ b/src/client/views/no-data-view/no-data-header-bar/no-data-header-bar.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { NoDataHeaderBar } from './no-data-header-bar';
 
 describe('NoDataHeaderBar', () => {

--- a/src/client/views/settings-view/data-cube-edit/data-cube-edit.tsx
+++ b/src/client/views/settings-view/data-cube-edit/data-cube-edit.tsx
@@ -18,7 +18,7 @@ require('./data-cube-edit.css');
 
 import * as React from 'react';
 import { List } from 'immutable';
-import { AttributeInfo } from 'plywood';
+import { AttributeInfo } from 'swiv-plywood';
 import { classNames } from '../../../utils/dom/dom';
 
 import { generateUniqueName } from '../../../../common/utils/string/string';

--- a/src/client/views/settings-view/settings-header-bar/settings-header-bar.mocha.tsx
+++ b/src/client/views/settings-view/settings-header-bar/settings-header-bar.mocha.tsx
@@ -22,7 +22,7 @@ import * as TestUtils from 'react-addons-test-utils';
 
 import '../../../utils/test-utils/index';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { SettingsHeaderBar } from './settings-header-bar';
 
 describe('SettingsHeaderBar', () => {

--- a/src/client/views/settings-view/settings-view.mocha.tsx
+++ b/src/client/views/settings-view/settings-view.mocha.tsx
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as React from 'react';
 import * as TestUtils from 'react-addons-test-utils';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 
 import { DataCubeMock, EssenceMock } from '../../../common/models/mocks';
 

--- a/src/client/views/settings-view/settings-view.tsx
+++ b/src/client/views/settings-view/settings-view.tsx
@@ -19,7 +19,7 @@ require('./settings-view.css');
 import * as React from 'react';
 import * as Q from 'q';
 
-import { $, Expression, Executor, Dataset } from 'plywood';
+import { $, Expression, Executor, Dataset } from 'swiv-plywood';
 import { DataCube, User, Customization } from '../../../common/models/index';
 import { MANIFESTS } from '../../../common/manifests/index';
 import { STRINGS } from '../../config/constants';

--- a/src/client/visualizations/bar-chart/bar-chart.tsx
+++ b/src/client/visualizations/bar-chart/bar-chart.tsx
@@ -19,7 +19,7 @@ require('./bar-chart.css');
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { List } from 'immutable';
-import { r, Range, Dataset, Datum, PseudoDatum, SortAction, PlywoodValue, Set, TimeRange, PlywoodRange, NumberRange } from 'plywood';
+import { r, Range, Dataset, Datum, PseudoDatum, SortAction, PlywoodValue, Set, TimeRange, PlywoodRange, NumberRange } from 'swiv-plywood';
 
 import {
   Stage,

--- a/src/client/visualizations/base-visualization/base-visualization.tsx
+++ b/src/client/visualizations/base-visualization/base-visualization.tsx
@@ -17,7 +17,7 @@
 require('./base-visualization.css');
 
 import * as React from 'react';
-import { $, ply, Expression, Dataset } from 'plywood';
+import { $, ply, Expression, Dataset } from 'swiv-plywood';
 import { Measure, VisualizationProps, DatasetLoad, Essence, Timekeeper } from '../../../common/models/index';
 
 import { SPLIT } from '../../config/constants';

--- a/src/client/visualizations/index.tsx
+++ b/src/client/visualizations/index.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { find } from 'plywood';
+import { find } from 'swiv-plywood';
 import { Manifest } from '../../common/models/manifest/manifest';
 import { BaseVisualization } from './base-visualization/base-visualization';
 

--- a/src/client/visualizations/line-chart/line-chart.tsx
+++ b/src/client/visualizations/line-chart/line-chart.tsx
@@ -22,7 +22,7 @@ import * as ReactDOM from 'react-dom';
 import * as d3 from 'd3';
 import { Duration } from 'chronoshift';
 import { r, $, ply, Expression, Dataset, Datum, TimeRange, TimeRangeJS, TimeBucketAction, SortAction,
-  PlywoodRange, NumberRangeJS, NumberRange, Range, NumberBucketAction } from 'plywood';
+  PlywoodRange, NumberRangeJS, NumberRange, Range, NumberBucketAction } from 'swiv-plywood';
 import { Essence, Splits, Colors, FilterClause, Dimension, Stage,
   Filter, Measure, DataCube, VisualizationProps, DatasetLoad } from '../../../common/models/index';
 import { LINE_CHART_MANIFEST } from '../../../common/manifests/line-chart/line-chart';

--- a/src/client/visualizations/table/table.tsx
+++ b/src/client/visualizations/table/table.tsx
@@ -19,7 +19,7 @@ require('./table.css');
 import { List } from 'immutable';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { $, ply, r, Expression, RefExpression, Executor, Dataset, Datum, PseudoDatum, TimeRange, Set, SortAction, NumberRange } from 'plywood';
+import { $, ply, r, Expression, RefExpression, Executor, Dataset, Datum, PseudoDatum, TimeRange, Set, SortAction, NumberRange } from 'swiv-plywood';
 import { formatterFromData, formatNumberRange, Formatter } from '../../../common/utils/formatter/formatter';
 import { Stage, Filter, FilterClause, Essence, VisStrategy, Splits, SplitCombine, Dimension,
   Measure, Colors, DataCube, VisualizationProps, DatasetLoad } from '../../../common/models/index';

--- a/src/client/visualizations/totals/totals.tsx
+++ b/src/client/visualizations/totals/totals.tsx
@@ -17,7 +17,7 @@
 require('./totals.css');
 
 import * as React from 'react';
-import { $, ply, Expression, Executor, Dataset } from 'plywood';
+import { $, ply, Expression, Executor, Dataset } from 'swiv-plywood';
 import { TOTALS_MANIFEST } from '../../../common/manifests/totals/totals';
 import { Stage, Essence, Timekeeper, VisualizationProps, DatasetLoad } from '../../../common/models/index';
 

--- a/src/common/manifests/bar-chart/bar-chart.ts
+++ b/src/common/manifests/bar-chart/bar-chart.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { $, SortAction } from 'plywood';
+import { $, SortAction } from 'swiv-plywood';
 import { Splits, DataCube, SplitCombine, Colors, Dimension } from '../../models/index';
 import { Manifest, Resolve } from '../../models/manifest/manifest';
 import { CircumstancesHandler } from '../../utils/circumstances-handler/circumstances-handler';

--- a/src/common/manifests/line-chart/line-chart.ts
+++ b/src/common/manifests/line-chart/line-chart.ts
@@ -15,7 +15,7 @@
  */
 
 import { List } from 'immutable';
-import { $, SortAction } from 'plywood';
+import { $, SortAction } from 'swiv-plywood';
 import { Splits, DataCube, SplitCombine, Colors, Dimension } from '../../models/index';
 import {
   CircumstancesHandler

--- a/src/common/manifests/table/table.ts
+++ b/src/common/manifests/table/table.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { $, SortAction } from 'plywood';
+import { $, SortAction } from 'swiv-plywood';
 import { Splits, DataCube, SplitCombine, Colors, Dimension } from '../../models/index';
 import { CircumstancesHandler } from '../../utils/circumstances-handler/circumstances-handler';
 import { Manifest, Resolve } from '../../models/manifest/manifest';

--- a/src/common/models/app-settings/app-settings.mocha.ts
+++ b/src/common/models/app-settings/app-settings.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { DataCubeMock } from '../data-cube/data-cube.mock';
 import { AppSettings } from './app-settings';
 import { AppSettingsMock } from './app-settings.mock';

--- a/src/common/models/app-settings/app-settings.mock.ts
+++ b/src/common/models/app-settings/app-settings.mock.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { $, Executor, Dataset, basicExecutorFactory } from 'plywood';
+import { $, Executor, Dataset, basicExecutorFactory } from 'swiv-plywood';
 import { MANIFESTS } from '../../../common/manifests/index';
 import { DataCubeMock } from '../data-cube/data-cube.mock';
 import { CollectionMock } from '../collection/collection.mock';

--- a/src/common/models/app-settings/app-settings.ts
+++ b/src/common/models/app-settings/app-settings.ts
@@ -16,7 +16,7 @@
 
 import { Class, Instance, isInstanceOf, immutableArraysEqual, immutableEqual } from 'immutable-class';
 import { ImmutableUtils } from '../../utils/index';
-import { Executor, findByName, overrideByName } from 'plywood';
+import { Executor, findByName, overrideByName } from 'swiv-plywood';
 import { hasOwnProperty } from '../../utils/general/general';
 import { Cluster, ClusterJS } from '../cluster/cluster';
 import { Customization, CustomizationJS } from '../customization/customization';

--- a/src/common/models/clicker/clicker.ts
+++ b/src/common/models/clicker/clicker.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Expression } from 'plywood';
+import { Expression } from 'swiv-plywood';
 import { Manifest } from '../manifest/manifest';
 import { Filter } from '../filter/filter';
 import { SplitCombine } from '../split-combine/split-combine';

--- a/src/common/models/cluster/cluster.ts
+++ b/src/common/models/cluster/cluster.ts
@@ -15,7 +15,7 @@
  */
 
 import { BaseImmutable, Property, isInstanceOf } from 'immutable-class';
-import { External } from 'plywood';
+import { External } from 'swiv-plywood';
 import { verifyUrlSafeName } from '../../utils/general/general';
 
 export type SupportedType = 'druid' | 'mysql' | 'postgres';

--- a/src/common/models/collection-tile/collection-tile.mocha.ts
+++ b/src/common/models/collection-tile/collection-tile.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { CollectionTileMock } from './collection-tile.mock';
 import { CollectionTile } from './collection-tile';
 

--- a/src/common/models/collection-tile/collection-tile.mock.ts
+++ b/src/common/models/collection-tile/collection-tile.mock.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { $ } from 'plywood';
+import { $ } from 'swiv-plywood';
 
 import { MANIFESTS } from "../../manifests/index";
 import { DataCubeMock } from "../data-cube/data-cube.mock";

--- a/src/common/models/collection-tile/collection-tile.ts
+++ b/src/common/models/collection-tile/collection-tile.ts
@@ -15,7 +15,7 @@
  */
 
 import { Class, Instance, isInstanceOf } from 'immutable-class';
-import { find } from 'plywood';
+import { find } from 'swiv-plywood';
 import { verifyUrlSafeName, makeTitle } from '../../utils/general/general';
 import { DataCube } from '../data-cube/data-cube';
 import { Essence, EssenceJS } from '../essence/essence';

--- a/src/common/models/collection/collection.mock.ts
+++ b/src/common/models/collection/collection.mock.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { $ } from 'plywood';
+import { $ } from 'swiv-plywood';
 import { DataCubeMock } from "../data-cube/data-cube.mock";
 import { CollectionTileMock } from "../collection-tile/collection-tile.mock";
 import { Collection, CollectionJS, CollectionContext } from './collection';

--- a/src/common/models/collection/collection.ts
+++ b/src/common/models/collection/collection.ts
@@ -15,7 +15,7 @@
  */
 
 import { Class, Instance, isInstanceOf, immutableArraysEqual } from 'immutable-class';
-import { findByName } from 'plywood';
+import { findByName } from 'swiv-plywood';
 
 import { Manifest } from '../manifest/manifest';
 import { CollectionTile, CollectionTileJS, CollectionTileContext } from '../index';

--- a/src/common/models/colors/colors.ts
+++ b/src/common/models/colors/colors.ts
@@ -15,7 +15,7 @@
  */
 
 import { Class, Instance, isInstanceOf, isImmutableClass } from 'immutable-class';
-import { $, Set, valueFromJS, valueToJS, FilterAction, LimitAction } from 'plywood';
+import { $, Set, valueFromJS, valueToJS, FilterAction, LimitAction } from 'swiv-plywood';
 import { hasOwnProperty } from '../../../common/utils/general/general';
 
 const NULL_COLOR = '#666666';

--- a/src/common/models/data-cube/data-cube.mocha.ts
+++ b/src/common/models/data-cube/data-cube.mocha.ts
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 import * as Q from 'q';
 
-import { $, Expression, AttributeInfo } from 'plywood';
+import { $, Expression, AttributeInfo } from 'swiv-plywood';
 import { Cluster } from "../cluster/cluster";
 import { DataCube, DataCubeJS } from './data-cube';
 import { DataCubeMock} from './data-cube.mock';

--- a/src/common/models/data-cube/data-cube.mock.ts
+++ b/src/common/models/data-cube/data-cube.mock.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { $, Executor, Dataset, basicExecutorFactory } from 'plywood';
+import { $, Executor, Dataset, basicExecutorFactory } from 'swiv-plywood';
 import { DataCube, DataCubeJS } from './data-cube';
 
 var executor = basicExecutorFactory({

--- a/src/common/models/data-cube/data-cube.ts
+++ b/src/common/models/data-cube/data-cube.ts
@@ -20,7 +20,7 @@ import { Class, Instance, isInstanceOf, immutableEqual, immutableArraysEqual, im
 import { Duration, Timezone, second } from 'chronoshift';
 import { $, ply, r, Expression, ExpressionJS, Executor, External, RefExpression, basicExecutorFactory, Dataset,
   Attributes, AttributeInfo, AttributeJSs, SortAction, SimpleFullType, DatasetFullType, PlyTypeSimple,
-  CustomDruidAggregations, CustomDruidTransforms, ExternalValue, findByName } from 'plywood';
+  CustomDruidAggregations, CustomDruidTransforms, ExternalValue, findByName } from 'swiv-plywood';
 import { hasOwnProperty, verifyUrlSafeName, makeUrlSafeName, makeTitle, immutableListsEqual } from '../../utils/general/general';
 import { getWallTimeString } from '../../utils/time/time';
 import { Dimension, DimensionJS } from '../dimension/dimension';

--- a/src/common/models/dimension/dimension.ts
+++ b/src/common/models/dimension/dimension.ts
@@ -16,7 +16,7 @@
 
 import { List } from 'immutable';
 import { Class, Instance, isInstanceOf, immutableArraysEqual } from 'immutable-class';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { verifyUrlSafeName, makeTitle } from '../../utils/general/general';
 import { Granularity, GranularityJS, granularityFromJS, granularityToJS, granularityEquals } from "../granularity/granularity";
 

--- a/src/common/models/drag-position/drag-position.mocha.ts
+++ b/src/common/models/drag-position/drag-position.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { DragPosition } from './drag-position';
 
 describe('DragPosition', () => {

--- a/src/common/models/essence/essence.mocha.ts
+++ b/src/common/models/essence/essence.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { MANIFESTS } from "../../manifests/index";
 import { Essence, EssenceJS, VisStrategy } from './essence';
 import { DataCube, Introspection } from "../data-cube/data-cube";
@@ -27,7 +27,7 @@ import { Splits } from "../splits/splits";
 import { SplitCombineMock } from "../split-combine/split-combine.mock";
 import { BAR_CHART_MANIFEST } from "../../manifests/bar-chart/bar-chart";
 import { SplitCombine } from "../split-combine/split-combine";
-import { RefExpression } from "plywood";
+import { RefExpression } from "swiv-plywood";
 
 describe('Essence', () => {
   var dataCubeJS = {

--- a/src/common/models/essence/essence.ts
+++ b/src/common/models/essence/essence.ts
@@ -18,7 +18,7 @@ import { List, OrderedSet, Iterable } from 'immutable';
 import { compressToBase64, decompressFromBase64 } from 'lz-string';
 import { Class, Instance, isInstanceOf, immutableEqual } from 'immutable-class';
 import { Timezone, Duration, minute } from 'chronoshift';
-import { $, Expression, RefExpression, TimeRange, ApplyAction, SortAction, Set, findByName } from 'plywood';
+import { $, Expression, RefExpression, TimeRange, ApplyAction, SortAction, Set, findByName } from 'swiv-plywood';
 import { hasOwnProperty } from '../../../common/utils/general/general';
 import { DataCube } from '../data-cube/data-cube';
 import { Filter, FilterJS } from '../filter/filter';

--- a/src/common/models/external-view/external-view.mocha.ts
+++ b/src/common/models/external-view/external-view.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { ExternalView } from './external-view';
 
 describe('ExternalView', () => {

--- a/src/common/models/external-view/external-view.ts
+++ b/src/common/models/external-view/external-view.ts
@@ -16,7 +16,7 @@
 
 import { Class, Instance, isInstanceOf } from 'immutable-class';
 import { Timezone } from 'chronoshift';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Essence, DataCube, Filter, Splits, Customization} from '../../../common/models/index';
 
 export interface LinkGenerator {

--- a/src/common/models/filter-clause/filter-clause.mocha.ts
+++ b/src/common/models/filter-clause/filter-clause.mocha.ts
@@ -18,7 +18,7 @@ import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
 import { Timezone, Duration } from 'chronoshift';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { FilterClause, FilterClauseJS } from './filter-clause';
 
 describe('FilterClause', () => {

--- a/src/common/models/filter-clause/filter-clause.ts
+++ b/src/common/models/filter-clause/filter-clause.ts
@@ -17,7 +17,7 @@
 import { Class, Instance, isInstanceOf } from 'immutable-class';
 import { Timezone, Duration, minute, day } from 'chronoshift';
 import { $, r, Expression, ExpressionJS, LiteralExpression, RefExpression, Set, SetJS,
-  ChainExpression, NotAction, OverlapAction, InAction, Range, TimeRange, Datum, NumberRange, MatchAction, ContainsAction } from 'plywood';
+  ChainExpression, NotAction, OverlapAction, InAction, Range, TimeRange, Datum, NumberRange, MatchAction, ContainsAction } from 'swiv-plywood';
 
 // Basically these represent
 // expression.in(selection) .not()?

--- a/src/common/models/filter/filter.mocha.ts
+++ b/src/common/models/filter/filter.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Filter, FilterJS } from './filter';
 
 describe('Filter', () => {

--- a/src/common/models/filter/filter.ts
+++ b/src/common/models/filter/filter.ts
@@ -17,7 +17,7 @@
 import { List } from 'immutable';
 import { Class, Instance, isInstanceOf } from 'immutable-class';
 import { Timezone, Duration } from 'chronoshift';
-import { $, r, Expression, LiteralExpression, ExpressionJS, InAction, Set, Range, TimeRange } from 'plywood';
+import { $, r, Expression, LiteralExpression, ExpressionJS, InAction, Set, Range, TimeRange } from 'swiv-plywood';
 import { immutableListsEqual } from '../../utils/general/general';
 import { Dimension } from '../dimension/dimension';
 import { FilterClause, FilterClauseJS, FilterSelection } from '../filter-clause/filter-clause';

--- a/src/common/models/granularity/granularity.mocha.ts
+++ b/src/common/models/granularity/granularity.mocha.ts
@@ -18,7 +18,7 @@ import { expect } from "chai";
 import { immutableArraysEqual } from "immutable-class";
 import { Duration } from "chronoshift";
 import { Granularity, granularityFromJS, granularityEquals, granularityToString, updateBucketSize, getGranularities, getDefaultGranularityForKind, getBestBucketUnitForRange } from "./granularity";
-import { TimeBucketAction, NumberBucketAction, TimeRange, NumberRange } from "plywood";
+import { TimeBucketAction, NumberBucketAction, TimeRange, NumberRange } from "swiv-plywood";
 
 var { WallTime } = require('chronoshift');
 if (!WallTime.rules) {

--- a/src/common/models/granularity/granularity.ts
+++ b/src/common/models/granularity/granularity.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { TimeBucketAction, NumberBucketAction, ActionJS, Action, ActionValue, TimeRange, PlywoodRange, NumberRange } from 'plywood';
+import { TimeBucketAction, NumberBucketAction, ActionJS, Action, ActionValue, TimeRange, PlywoodRange, NumberRange } from 'swiv-plywood';
 import { day, hour, minute, Timezone, Duration } from 'chronoshift';
 
 import {

--- a/src/common/models/highlight/highlight.mocha.ts
+++ b/src/common/models/highlight/highlight.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Highlight, HighlightJS } from './highlight';
 
 describe('Highlight', () => {

--- a/src/common/models/highlight/highlight.ts
+++ b/src/common/models/highlight/highlight.ts
@@ -16,7 +16,7 @@
 
 import { List } from 'immutable';
 import { Class, Instance, isInstanceOf, immutableArraysEqual } from 'immutable-class';
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Dimension } from '../dimension/dimension';
 import { Filter, FilterJS } from '../filter/filter';
 

--- a/src/common/models/measure/measure.mocha.ts
+++ b/src/common/models/measure/measure.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, AttributeInfo } from 'plywood';
+import { $, AttributeInfo } from 'swiv-plywood';
 import { Measure, MeasureJS } from './measure';
 
 describe('Measure', () => {

--- a/src/common/models/measure/measure.ts
+++ b/src/common/models/measure/measure.ts
@@ -17,7 +17,7 @@
 import { List } from 'immutable';
 import { BaseImmutable, Property, isInstanceOf } from 'immutable-class';
 import * as numeral from 'numeral';
-import { $, Expression, Datum, ApplyAction, AttributeInfo, ChainExpression, deduplicateSort } from 'plywood';
+import { $, Expression, Datum, ApplyAction, AttributeInfo, ChainExpression, deduplicateSort } from 'swiv-plywood';
 import { verifyUrlSafeName, makeTitle, makeUrlSafeName } from '../../utils/general/general';
 
 function formatFnFactory(format: string): (n: number) => string {

--- a/src/common/models/refresh-rule/refresh-rule.mocha.ts
+++ b/src/common/models/refresh-rule/refresh-rule.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { RefreshRule, RefreshRuleJS } from './refresh-rule';
 
 describe('RefreshRule', () => {

--- a/src/common/models/sort-on/sort-on.mocha.ts
+++ b/src/common/models/sort-on/sort-on.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { SortOn, SortOnJS } from './sort-on';
 
 describe('SortOn', () => {

--- a/src/common/models/sort-on/sort-on.mock.ts
+++ b/src/common/models/sort-on/sort-on.mock.ts
@@ -15,7 +15,7 @@
  */
 
 import { SortOn, SortOnJS } from './sort-on';
-import { $ } from 'plywood';
+import { $ } from 'swiv-plywood';
 
 export class SortOnMock {
   public static get DEFAULT_A_JS(): SortOnJS {

--- a/src/common/models/sort-on/sort-on.ts
+++ b/src/common/models/sort-on/sort-on.ts
@@ -15,7 +15,7 @@
  */
 
 import { Class, Instance, isInstanceOf } from 'immutable-class';
-import { $, Expression, RefExpression, SortAction } from 'plywood';
+import { $, Expression, RefExpression, SortAction } from 'swiv-plywood';
 import { Dimension, DimensionJS } from '../dimension/dimension';
 import { Measure, MeasureJS } from '../measure/measure';
 import { DataCube } from '../data-cube/data-cube';

--- a/src/common/models/split-combine/split-combine.mocha.ts
+++ b/src/common/models/split-combine/split-combine.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { SplitCombine, SplitCombineJS } from './split-combine';
 
 describe('SplitCombine', () => {

--- a/src/common/models/split-combine/split-combine.ts
+++ b/src/common/models/split-combine/split-combine.ts
@@ -17,7 +17,7 @@
 import { List } from 'immutable';
 import { Class, Instance, isInstanceOf } from 'immutable-class';
 import { Timezone, Duration, day, hour } from 'chronoshift';
-import { $, Expression, ChainExpression, ExpressionJS, Action, ActionJS, SortAction, LimitAction, TimeBucketAction, NumberBucketAction } from 'plywood';
+import { $, Expression, ChainExpression, ExpressionJS, Action, ActionJS, SortAction, LimitAction, TimeBucketAction, NumberBucketAction } from 'swiv-plywood';
 import { Dimension } from '../dimension/dimension';
 
 export interface SplitCombineValue {

--- a/src/common/models/splits/splits.mocha.ts
+++ b/src/common/models/splits/splits.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Splits, SplitsJS } from './splits';
 
 describe('Splits', () => {

--- a/src/common/models/splits/splits.ts
+++ b/src/common/models/splits/splits.ts
@@ -17,14 +17,14 @@
 import { List } from 'immutable';
 import { Class, Instance, isInstanceOf, immutableArraysEqual } from 'immutable-class';
 import { Timezone, Duration, day, hour } from 'chronoshift';
-import { $, Expression, RefExpression, TimeRange, TimeBucketAction, SortAction, NumberRange, Range } from 'plywood';
+import { $, Expression, RefExpression, TimeRange, TimeBucketAction, SortAction, NumberRange, Range } from 'swiv-plywood';
 import { immutableListsEqual } from '../../utils/general/general';
 import { Dimension } from '../dimension/dimension';
 import { Measure } from '../measure/measure';
 import { Filter } from '../filter/filter';
 import { Timekeeper } from '../timekeeper/timekeeper';
 import { SplitCombine, SplitCombineJS, SplitCombineContext } from '../split-combine/split-combine';
-import { NumberBucketAction } from "plywood";
+import { NumberBucketAction } from "swiv-plywood";
 import { getDefaultGranularityForKind, getBestBucketUnitForRange } from "../granularity/granularity";
 
 function withholdSplit(splits: List<SplitCombine>, split: SplitCombine, allowIndex: number): List<SplitCombine> {

--- a/src/common/models/stage/stage.mocha.ts
+++ b/src/common/models/stage/stage.mocha.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { testImmutableClass } from 'immutable-class-tester';
 
-import { $, Expression } from 'plywood';
+import { $, Expression } from 'swiv-plywood';
 import { Stage, StageJS } from './stage';
 import { StageMock } from './stage.mock';
 

--- a/src/common/models/timekeeper/timekeeper.ts
+++ b/src/common/models/timekeeper/timekeeper.ts
@@ -15,7 +15,7 @@
  */
 
 import { BaseImmutable, Property, isInstanceOf } from 'immutable-class';
-import { findByName, overrideByName } from 'plywood';
+import { findByName, overrideByName } from 'swiv-plywood';
 import { TimeTag, TimeTagJS } from '../time-tag/time-tag';
 
 // I am: export * from './timekeeper/timekeeper';

--- a/src/common/models/visualization-props/visualization-props.ts
+++ b/src/common/models/visualization-props/visualization-props.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Dataset } from 'plywood';
+import { Dataset } from 'swiv-plywood';
 import { Fn } from '../../utils/general/general';
 import { Clicker, Stage, Essence, Timekeeper, DeviceSize } from '../index';
 

--- a/src/common/utils/formatter/formatter.ts
+++ b/src/common/utils/formatter/formatter.ts
@@ -17,7 +17,7 @@
 import * as numeral from 'numeral';
 import { Timezone } from 'chronoshift';
 
-import { NumberRange, TimeRange, LiteralExpression } from 'plywood';
+import { NumberRange, TimeRange, LiteralExpression } from 'swiv-plywood';
 
 import { Dimension, FilterClause, Filter } from '../../models/index';
 import { DisplayYear, formatTimeRange } from '../../utils/time/time';

--- a/src/common/utils/general/general.ts
+++ b/src/common/utils/general/general.ts
@@ -16,7 +16,7 @@
 
 import { List } from 'immutable';
 import { immutableArraysEqual, Equalable } from 'immutable-class';
-import { TimeRange, NumberRange, PlywoodRange } from 'plywood';
+import { TimeRange, NumberRange, PlywoodRange } from 'swiv-plywood';
 
 // The most generic function
 export interface Fn {

--- a/src/common/utils/time/time.mocha.ts
+++ b/src/common/utils/time/time.mocha.ts
@@ -16,7 +16,7 @@
 
 import { expect } from 'chai';
 import { Timezone, Duration, day, month } from 'chronoshift';
-import { TimeRange } from 'plywood';
+import { TimeRange } from 'swiv-plywood';
 import { datesEqual, prependDays, appendDays, getEndWallTimeInclusive, getWallTimeDay, getWallTimeMonthWithYear, formatTimeBasedOnGranularity, formatTimeRange } from './time';
 
 var { WallTime } = require('chronoshift');

--- a/src/common/utils/time/time.ts
+++ b/src/common/utils/time/time.ts
@@ -16,7 +16,7 @@
 
 import * as d3 from 'd3';
 import { Timezone, Duration, WallTime, month, day, hour, minute } from 'chronoshift';
-import { TimeRange } from 'plywood';
+import { TimeRange } from 'swiv-plywood';
 
 const FORMAT_WITH_YEAR = d3.time.format('%b %-d, %Y');
 const FORMAT_WITHOUT_YEAR = d3.time.format('%b %-d');

--- a/src/common/utils/yaml-helper/yaml-helper.ts
+++ b/src/common/utils/yaml-helper/yaml-helper.ts
@@ -16,7 +16,7 @@
 
 import * as yaml from 'js-yaml';
 
-import { $, AttributeInfo, RefExpression } from 'plywood';
+import { $, AttributeInfo, RefExpression } from 'swiv-plywood';
 import { DataCube, Dimension, Measure, Cluster, AppSettings, Collection, CollectionTile } from '../../../common/models/index';
 import { DATA_CUBE, DIMENSION, MEASURE, CLUSTER, COLLECTION, COLLECTION_ITEM } from '../../../common/models/labels';
 

--- a/src/server/routes/mkurl/mkurl.mocha.ts
+++ b/src/server/routes/mkurl/mkurl.mocha.ts
@@ -18,7 +18,7 @@ import * as Q from 'q';
 import * as express from 'express';
 import { Response } from 'express';
 import * as supertest from 'supertest';
-import { $, ply, r } from 'plywood';
+import { $, ply, r } from 'swiv-plywood';
 import * as bodyParser from 'body-parser';
 
 import { AppSettings } from '../../../common/models/index';

--- a/src/server/routes/plyql/plyql.ts
+++ b/src/server/routes/plyql/plyql.ts
@@ -15,7 +15,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { $, Expression, ChainExpression, RefExpression, External, Datum, Dataset, TimeRange, ApplyAction } from 'plywood';
+import { $, Expression, ChainExpression, RefExpression, External, Datum, Dataset, TimeRange, ApplyAction } from 'swiv-plywood';
 import { Timezone, WallTime, Duration } from 'chronoshift';
 
 import { SwivRequest } from '../../utils/index';

--- a/src/server/routes/plywood/plywood.mocha.ts
+++ b/src/server/routes/plywood/plywood.mocha.ts
@@ -18,7 +18,7 @@ import * as Q from 'q';
 import * as express from 'express';
 import { Response } from 'express';
 import * as supertest from 'supertest';
-import { $, ply, r } from 'plywood';
+import { $, ply, r } from 'swiv-plywood';
 import * as bodyParser from 'body-parser';
 
 import { AppSettings } from '../../../common/models/index';

--- a/src/server/routes/plywood/plywood.ts
+++ b/src/server/routes/plywood/plywood.ts
@@ -15,7 +15,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { $, Expression, RefExpression, External, Datum, Dataset, PlywoodValue, TimeRange, basicExecutorFactory, Executor, AttributeJSs } from 'plywood';
+import { $, Expression, RefExpression, External, Datum, Dataset, PlywoodValue, TimeRange, basicExecutorFactory, Executor, AttributeJSs } from 'swiv-plywood';
 import { Timezone, WallTime, Duration } from 'chronoshift';
 
 import { SwivRequest } from '../../utils/index';

--- a/src/server/utils/cluster-manager/cluster-manager.ts
+++ b/src/server/utils/cluster-manager/cluster-manager.ts
@@ -16,7 +16,7 @@
 
 import * as path from 'path';
 import * as Q from 'q';
-import { External, findByName } from 'plywood';
+import { External, findByName } from 'swiv-plywood';
 import { Logger } from 'logger-tracker';
 import { DruidRequestDecorator } from 'plywood-druid-requester';
 import { properRequesterFactory } from '../requester/requester';

--- a/src/server/utils/file-manager/file-manager.ts
+++ b/src/server/utils/file-manager/file-manager.ts
@@ -17,7 +17,7 @@
 import * as path from 'path';
 import * as Q from 'q';
 import * as fs from 'fs-promise';
-import { Dataset, Expression, PseudoDatum } from 'plywood';
+import { Dataset, Expression, PseudoDatum } from 'swiv-plywood';
 import { Logger } from 'logger-tracker';
 
 import { parseData } from '../../../common/utils/parser/parser';

--- a/src/server/utils/requester/requester.ts
+++ b/src/server/utils/requester/requester.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { $, retryRequesterFactory, verboseRequesterFactory, concurrentLimitRequesterFactory } from 'plywood';
+import { $, retryRequesterFactory, verboseRequesterFactory, concurrentLimitRequesterFactory } from 'swiv-plywood';
 import { druidRequesterFactory, DruidRequestDecorator } from 'plywood-druid-requester';
 import { mySqlRequesterFactory } from 'plywood-mysql-requester';
 import { postgresRequesterFactory } from 'plywood-postgres-requester';

--- a/src/server/utils/settings-manager/settings-manager.ts
+++ b/src/server/utils/settings-manager/settings-manager.ts
@@ -15,7 +15,7 @@
  */
 
 import * as Q from 'q';
-import { External, Dataset, basicExecutorFactory, find } from 'plywood';
+import { External, Dataset, basicExecutorFactory, find } from 'swiv-plywood';
 import { Logger } from 'logger-tracker';
 import { pluralIfNeeded } from '../../../common/utils/general/general';
 import { TimeMonitor } from "../../../common/utils/time-monitor/time-monitor";

--- a/test/simulate/examples.mocha.js
+++ b/test/simulate/examples.mocha.js
@@ -16,7 +16,7 @@
 
 const expect = require('chai').expect;
 const request = require('request');
-const plywood = require('plywood');
+const plywood = require('swiv-plywood');
 const spawnServer = require('node-spawn-server');
 
 const $ = plywood.$;

--- a/test/simulate/tracking.mocha.js
+++ b/test/simulate/tracking.mocha.js
@@ -17,7 +17,7 @@
 const expect = require('chai').expect;
 const Q = require('q');
 const request = require('request');
-const plywood = require('plywood');
+const plywood = require('swiv-plywood');
 const spawnServer = require('node-spawn-server');
 const eventCollector = require('../utils/event-collector');
 

--- a/test/utils/basic-string.js
+++ b/test/utils/basic-string.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const Expression = require('plywood').Expression;
+const Expression = require('swiv-plywood').Expression;
 
 function basicString(thing) {
   return thing.name + ' ~ ' + thing.formula;


### PR DESCRIPTION
To have this working against druid 0.10.x versions, this fix is needed - https://github.com/implydata/plywood/commit/71703bbe49a5b299d6065d259d71194a9d66f5ae
We cannot upgrade just `plywood` to get this fix as that would require change in swiv code as well. Therefore, `swiv-plywood` is a fork of `plywood` with the required patch.

When I was testing the changes I noticed that `view raw data` caused swiv to crash. Same problem is reported here - https://groups.google.com/forum/#!msg/imply-user-group/ZRtIYZTggF8/jodTadP3AAAJ

Interestingly it started working again without any change, I have deployed this against a druid cluster and testing the fix.