### PR TITLE
Restore the previous end time generation

### DIFF
--- a/src/common/models/filter-clause/filter-clause.ts
+++ b/src/common/models/filter-clause/filter-clause.ts
@@ -75,7 +75,7 @@ export class FilterClause implements Instance<FilterClauseValue, FilterClauseJS>
 
   static evaluate(selection: Expression, now: Date, maxTime: Date, timezone: Timezone): TimeRange {
     if (!selection) return null;
-    var maxTimeMinuteTop = minute.ceil(maxTime || now, timezone);
+    var maxTimeMinuteTop = minute.shift(minute.floor(maxTime || now, timezone), timezone, 1);
     var datum: Datum = {};
     datum[FilterClause.NOW_REF_NAME] = now;
     datum[FilterClause.MAX_TIME_REF_NAME] = maxTimeMinuteTop;


### PR DESCRIPTION
The current date picker with the "latest" selection always discard the last druid interval.
My guess is that the bug has been introduce with this PR https://github.com/implydata/pivot/pull/358 so I have reverted the problematic line. Testing against a running druid cluster seems to work